### PR TITLE
misc: dismiss kotlin.reflect and clean the code

### DIFF
--- a/clapfab/build.gradle
+++ b/clapfab/build.gradle
@@ -62,7 +62,6 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }
 repositories {
     mavenCentral()

--- a/clapfab/src/main/java/com/wajahatkarim3/clapfab/ClapFAB.kt
+++ b/clapfab/src/main/java/com/wajahatkarim3/clapfab/ClapFAB.kt
@@ -3,33 +3,28 @@ package com.wajahatkarim3.clapfab
 import android.animation.ObjectAnimator
 import android.content.Context
 import android.content.res.ColorStateList
-import android.graphics.Color
 import android.graphics.PorterDuff
-import android.graphics.drawable.ShapeDrawable
-import android.graphics.drawable.shapes.OvalShape
 import android.os.CountDownTimer
 import android.support.design.widget.FloatingActionButton
 import android.support.v4.content.ContextCompat
 import android.support.v4.widget.ImageViewCompat
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.view.animation.DecelerateInterpolator
-import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import com.github.florent37.viewanimator.ViewAnimator
-import kotlin.math.max
 
 /**
  * Created by Wajahat Karim on 2/7/2018.
  * @author Wajahat Karim
  */
-class ClapFAB : RelativeLayout
+class ClapFAB
+@JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
+: RelativeLayout(context, attrs, defStyleAttr)
 {
-    private val TAG = ClapFAB::class.simpleName
+    private val TAG = ClapFAB::class.java.simpleName
 
     // Data Values
     private var clapCount = 0
@@ -103,13 +98,7 @@ class ClapFAB : RelativeLayout
      */
     var clapListener: OnClapListener? = null
 
-
-    constructor(context: Context) : this(context, null)
-
-    constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
-
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-    {
+    init {
         init(context, attrs)
     }
 


### PR DESCRIPTION
- Dismissed using kotlin.reflect since it was just used for getting the class name
- Removed unused import statements
- Use @JvmOverloads to make the constructor looks more easier.

Hi @wajahatkarim3 
Thanks for your this great and helpful View. Currently I cannot use your View since you are using `kotlin.reflec` that I don't want to use. I made some changes you can totally off for that and I wish you can consider to merge it and deploy it. I will like to use it :)