### PR TITLE
Decrease size of ClapFAB to set margins

### DIFF
--- a/app/src/main/res/layout/activity_demo.xml
+++ b/app/src/main/res/layout/activity_demo.xml
@@ -65,8 +65,6 @@
         android:id="@+id/clapFAB4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/activity_demo.xml
+++ b/app/src/main/res/layout/activity_demo.xml
@@ -61,5 +61,14 @@
         app:layout_constraintStart_toEndOf="@+id/clapFAB"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <com.wajahatkarim3.clapfab.ClapFAB
+        android:id="@+id/clapFAB4"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 
 </android.support.constraint.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.41'
+    ext.kotlin_version = '1.2.71'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/clapfab/build.gradle
+++ b/clapfab/build.gradle
@@ -17,7 +17,7 @@ ext {
     siteUrl = 'https://github.com/wajahatkarim3/MediumClap-Android'
     gitUrl = 'https://github.com/wajahatkarim3/MediumClap-Android.git'
 
-    libraryVersion = '1.0.1'
+    libraryVersion = '1.0.2'
 
     developerId = 'wajahatkarim3'
     developerName = 'Wajahat Karim'

--- a/clapfab/src/main/res/layout/clap_fab_layout.xml
+++ b/clapfab/src/main/res/layout/clap_fab_layout.xml
@@ -3,8 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
-    android:layout_width="wrap_content"
-    android:layout_height="400dp">
+    android:layout_width="100dp"
+    android:layout_height="200dp">
 
     <TextView
         android:id="@+id/txtCountCircle"
@@ -37,8 +37,8 @@
 
     <com.wajahatkarim3.clapfab.DotsView
         android:id="@+id/dotsView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
         android:layout_marginBottom="8dp"
         android:layout_centerHorizontal="true"
         android:layout_alignParentBottom="true"

--- a/clapfab/src/main/res/layout/clap_fab_layout.xml
+++ b/clapfab/src/main/res/layout/clap_fab_layout.xml
@@ -4,13 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="wrap_content"
-    android:layout_height="match_parent">
+    android:layout_height="400dp">
 
     <TextView
         android:id="@+id/txtCountCircle"
         android:layout_width="40dp"
         android:layout_height="40dp"
-        android:layout_centerInParent="true"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true"
         android:background="@drawable/circle_shape_background"
         android:elevation="7dp"
         android:gravity="center"
@@ -24,7 +25,9 @@
         android:id="@+id/fabDemoClap"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="8dp"
         app:backgroundTint="@android:color/white"
         tools:backgroundTint="@color/colorClapIcon"
         app:elevation="4dp"
@@ -36,7 +39,9 @@
         android:id="@+id/dotsView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:layout_marginBottom="8dp"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true"
         />
 
 </RelativeLayout>

--- a/clapfab/src/main/res/values/dimens.xml
+++ b/clapfab/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="default_bottom_margin_fab">8dp</dimen>
+</resources>


### PR DESCRIPTION
Adds some code to decrease the size of ```ClapFAB``` from ```match_parent``` to ```200dp```. This allows to set custom margins on ```ClapFAB``` in layouts.
Also, it fixes issue #10 almost.