### PR TITLE
Added option to set default clap count and format clap count 

### DIFF
--- a/app/src/main/java/com/wajahatkarim3/mediumclap_android/DemoActivity.kt
+++ b/app/src/main/java/com/wajahatkarim3/mediumclap_android/DemoActivity.kt
@@ -16,6 +16,12 @@ class DemoActivity : AppCompatActivity() {
         clapFAB2.clapListener = listener
         clapFAB3.clapListener = listener
         clapFAB4.clapListener = listener
+
+        //Set max clap count
+        clapFAB4.maxCount = 20000
+
+        //Set Default clap count
+        clapFAB4.setClapCount(9999)
     }
 
     private val listener = object : ClapFAB.OnClapListener{

--- a/app/src/main/res/layout/activity_demo.xml
+++ b/app/src/main/res/layout/activity_demo.xml
@@ -55,6 +55,8 @@
         app:cf_filled_icon="@drawable/ic_favorite_black_24dp"
         app:cf_filled_icon_color="@color/colorPrimary"
         app:cf_max_clap_count="20"
+        app:cf_format_clap_count="false"
+        app:cf_clap_count="10"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toBottomOf="parent" />
 
@@ -63,6 +65,7 @@
         android:id="@+id/clapFAB4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:cf_format_clap_count="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/clapfab/src/main/java/com/wajahatkarim3/clapfab/ClapFAB.kt
+++ b/clapfab/src/main/java/com/wajahatkarim3/clapfab/ClapFAB.kt
@@ -33,6 +33,7 @@ class ClapFAB
     private var isCirlceAvailable = false
     private var isHideAnimStopped = false
     private var hidingStarted = false
+    private var formatClapCount = true;
 
     // Animations
     private var fabScaleAnimation_1: ViewAnimator? = null
@@ -130,7 +131,11 @@ class ClapFAB
                 }
 
                 clapListener?.onFabClapped(this, clapCount, false)
-                txtCountCircle.text = "+$clapCount"
+                if(formatClapCount){
+                    txtCountCircle.text = NumberUtil.format(clapCount)
+                }else{
+                    txtCountCircle.text = "$clapCount"
+                }
 
                 playActualFabAnim()
             }
@@ -148,6 +153,8 @@ class ClapFAB
             val typedArray = context.obtainStyledAttributes(attributes, R.styleable.clap_fab, 0, 0)
             typedArray.apply {
                 maxCount = getInt(R.styleable.clap_fab_cf_max_clap_count, 50)
+                clapCount = getInt(R.styleable.clap_fab_cf_clap_count, 0)
+                formatClapCount = getBoolean(R.styleable.clap_fab_cf_clap_count, true)
                 defaultIconResId = getResourceId(R.styleable.clap_fab_cf_default_icon, R.drawable.ic_clap_hands_outline)
                 filledIconResId = getResourceId(R.styleable.clap_fab_cf_filled_icon, R.drawable.ic_clap_hands_filled)
                 defaultIconColorRes = getResourceId(R.styleable.clap_fab_cf_default_icon_color, R.color.colorClapIcon)
@@ -320,6 +327,17 @@ class ClapFAB
                     //circleHideMoveAnimation_4 = null
                 }
                 .start()
+    }
+
+    /**
+     * Set Default clap count
+     *
+     * @param count Default clap count. It can be greater than {@link maxCount}
+     */
+    fun setClapCount(count:Int){
+        if(clapCount<=maxCount){
+            clapCount = count
+        }
     }
 
     interface OnClapListener {

--- a/clapfab/src/main/java/com/wajahatkarim3/clapfab/ClapFAB.kt
+++ b/clapfab/src/main/java/com/wajahatkarim3/clapfab/ClapFAB.kt
@@ -154,7 +154,7 @@ class ClapFAB
             typedArray.apply {
                 maxCount = getInt(R.styleable.clap_fab_cf_max_clap_count, 50)
                 clapCount = getInt(R.styleable.clap_fab_cf_clap_count, 0)
-                formatClapCount = getBoolean(R.styleable.clap_fab_cf_clap_count, true)
+                formatClapCount = getBoolean(R.styleable.clap_fab_cf_format_clap_count, true)
                 defaultIconResId = getResourceId(R.styleable.clap_fab_cf_default_icon, R.drawable.ic_clap_hands_outline)
                 filledIconResId = getResourceId(R.styleable.clap_fab_cf_filled_icon, R.drawable.ic_clap_hands_filled)
                 defaultIconColorRes = getResourceId(R.styleable.clap_fab_cf_default_icon_color, R.color.colorClapIcon)

--- a/clapfab/src/main/java/com/wajahatkarim3/clapfab/NumberUtil.kt
+++ b/clapfab/src/main/java/com/wajahatkarim3/clapfab/NumberUtil.kt
@@ -1,0 +1,40 @@
+package com.wajahatkarim3.clapfab
+
+import java.util.*
+
+
+/**
+ * Taken From
+ * https://stackoverflow.com/questions/4753251/how-to-go-about-formatting-1200-to-1-2k-in-java#answer-30661479
+ *
+ * @author assylias
+ * @version 1.0
+ */
+object NumberUtil {
+
+    private val suffixes = TreeMap<Long, String>()
+
+    init {
+        suffixes[1_000L] = "K";
+        suffixes[1_000_000L] = "M";
+        suffixes[1_000_000_000L] = "G";
+        suffixes[1_000_000_000_000L] = "T";
+        suffixes[1_000_000_000_000_000L] = "P";
+        suffixes[1_000_000_000_000_000_000L] = "E";
+    }
+
+    fun format(value: Int): String {
+        if (value == Int.MIN_VALUE) return format(Int.MIN_VALUE + 1)
+        if (value < 0) return "-" + format(-value)
+        if (value < 1000) return value.toString() //deal with easy case
+
+        val e = suffixes.floorEntry(value.toLong())
+        val divideBy = e.key
+        val suffix = e.value
+
+        val truncated = (value / (divideBy!! / 10)).toFloat() //the number part of the output times 10
+        val hasDecimal = truncated < 100 && truncated / 10.0 != (truncated / 10).toDouble()
+        return if (hasDecimal) (truncated / 10.0).toString() + suffix else (truncated / 10).toString() + suffix
+    }
+
+}

--- a/clapfab/src/main/res/values/attrs.xml
+++ b/clapfab/src/main/res/values/attrs.xml
@@ -2,6 +2,8 @@
 <resources>
     <declare-styleable name="clap_fab">
         <attr name="cf_max_clap_count" format="integer"/>
+        <attr name="cf_clap_count" format="integer"/>
+        <attr name="cf_format_clap_count" format="boolean"/>
         <attr name="cf_default_icon" format="reference"/>
         <attr name="cf_filled_icon" format="reference"/>
         <attr name="cf_default_icon_color" format="reference"/>


### PR DESCRIPTION
Change Log:

- Added option to set default clap count.  It will be very helpful to set clap count from the rest API response.

```
To set clap count from xml:
    app:cf_clap_count="10"
To set clap count programatically:
     clapFAB.setClapCount(10)
```
- Added option to format clap count(Will be helpful when count increase beyond 999). Formatter will be enabled by default.
```
To enable/disable formatter:
    app:cf_format_clap_count="true"
    app:cf_format_clap_count="false"
```